### PR TITLE
Updated vehicle properties values

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -627,7 +627,8 @@ ESX.Game.GetVehicleProperties = function(vehicle)
 			modTrimB          = GetVehicleMod(vehicle, 44),
 			modTank           = GetVehicleMod(vehicle, 45),
 			modWindows        = GetVehicleMod(vehicle, 46),
-			modLivery         = GetVehicleLivery(vehicle)
+			modUnk47          = GetVehicleMod(vehicle, 47),
+			modLivery         = GetVehicleMod(vehicle, 48)
 		}
 	else
 		return
@@ -696,6 +697,8 @@ ESX.Game.SetVehicleProperties = function(vehicle, props)
 		if props.modXenon then ToggleVehicleMod(vehicle,  22, props.modXenon) end
 		if props.modFrontWheels then SetVehicleMod(vehicle, 23, props.modFrontWheels, false) end
 		if props.modBackWheels then SetVehicleMod(vehicle, 24, props.modBackWheels, false) end
+		if props.modFrontTyres then SetVehicleMod(vehicle, 23, props.modFrontTyres, true) end
+		if props.modBackTyres then SetVehicleMod(vehicle, 24, props.modBackTyres, true) end
 		if props.modPlateHolder then SetVehicleMod(vehicle, 25, props.modPlateHolder, false) end
 		if props.modVanityPlate then SetVehicleMod(vehicle, 26, props.modVanityPlate, false) end
 		if props.modTrimA then SetVehicleMod(vehicle, 27, props.modTrimA, false) end
@@ -721,7 +724,6 @@ ESX.Game.SetVehicleProperties = function(vehicle, props)
 
 		if props.modLivery then
 			SetVehicleMod(vehicle, 48, props.modLivery, false)
-			SetVehicleLivery(vehicle, props.modLivery)
 		end
 	end
 end

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -721,6 +721,7 @@ ESX.Game.SetVehicleProperties = function(vehicle, props)
 		if props.modTrimB then SetVehicleMod(vehicle, 44, props.modTrimB, false) end
 		if props.modTank then SetVehicleMod(vehicle, 45, props.modTank, false) end
 		if props.modWindows then SetVehicleMod(vehicle, 46, props.modWindows, false) end
+		if props.modUnk47 then SetVehicleMod(vehicle, 47, props.modUnk47, false) end
 
 		if props.modLivery then
 			SetVehicleMod(vehicle, 48, props.modLivery, false)


### PR DESCRIPTION
Tires are now applied when using `ESX.Game.SetVehicleProperties(...)`.
They are already saved in `ESX.Game.GetVehicleProperties(...)` thanks to `GetVehicleMod(vehicle, 23)` & `GetVehicleMod(vehicle, 24)`.

Old livery natives doesnt works sometimes. Its way better to use VehicleMod 48 instead
- Replaced `GetVehicleLivery()` by `GetVehicleMod(vehicle, 48)` 
- Removed `SetVehicleLivery()` cause `SetVehicleMod(vehicle, 48, props.modLivery, false)` do the same job perfectly.