### PR TITLE
Removed command error chat notification

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -246,14 +246,6 @@ function loadESXPlayer(identifier, playerId, isNew)
 	end)
 end
 
-AddEventHandler('chatMessage', function(playerId, author, message)
-	if message:sub(1, 1) == '/' and playerId > 0 then
-		CancelEvent()
-		local commandName = message:sub(1):gmatch("%w+")()
-		TriggerClientEvent('chat:addMessage', playerId, {args = {'^1SYSTEM', _U('commanderror_invalidcommand', commandName)}})
-	end
-end)
-
 local Logout = function(playerId)
 	local xPlayer = ESX.GetPlayerFromId(playerId)
 	if xPlayer then


### PR DESCRIPTION
So, I worked with RegisterCommands the last couple of days, and had some unwanted functionality stemming from ESX.

When creating RegisterCommands with a + sign in the name, ESX will pick this up and throw a chat message about the command is invalid, even tho it’s actually there, just not using ESX’s RegisterCommand syntax.

In my perspective it feels like an oversight and random fluff, that dos not have a clear purpose, besides doing false positives on commands not using ESX.RegisterCommand syntax.

Not sure if there is a reasoning behind keeping this.