### PR TITLE
Removed unused translation string - Bug fixed TPM

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -256,6 +256,8 @@ RegisterNetEvent('esx:tpm', function()
 					SetPedCoordsKeepVehicle(playerPed, waypointCoords.x, waypointCoords.y, height + 0.0)
 					break
 				end
+
+				Wait(5)
 			end
 			TriggerEvent('chat:addMessage', 'Successfully Teleported')
 		else

--- a/locales/br.lua
+++ b/locales/br.lua
@@ -97,7 +97,6 @@ Locales['br'] = {
   ['commanderror_invaliditem'] = 'item invalido',
   ['commanderror_invalidweapon'] = 'invalid weapon',
   ['commanderror_console'] = 'that command can not be run from console',
-  ['commanderror_invalidcommand'] = '^3%s^0 is not an valid command!',
   ['commanderror_invalidplayerid'] = 'there is no player online matching that server id',
   ['commandgeneric_playerid'] = 'o ID do jogador',
 

--- a/locales/cs.lua
+++ b/locales/cs.lua
@@ -97,7 +97,6 @@ Locales['cs'] = {
   ['commanderror_invaliditem'] = 'invalid item name',
   ['commanderror_invalidweapon'] = 'invalid weapon',
   ['commanderror_console'] = 'that command can not be run from console',
-  ['commanderror_invalidcommand'] = '^3%s^0 is not an valid command!',
   ['commanderror_invalidplayerid'] = 'there is no player online matching that server id',
   ['commandgeneric_playerid'] = 'player id',
 

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -97,7 +97,6 @@ Locales['de'] = {
   ['commanderror_invaliditem'] = 'invalid item name',
   ['commanderror_invalidweapon'] = 'invalid weapon',
   ['commanderror_console'] = 'that command can not be run from console',
-  ['commanderror_invalidcommand'] = '^3%s^0 is not an valid command!',
   ['commanderror_invalidplayerid'] = 'there is no player online matching that server id',
   ['commandgeneric_playerid'] = 'player id',
 

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -97,7 +97,6 @@ Locales['en'] = {
   ['commanderror_invaliditem'] = 'invalid item name',
   ['commanderror_invalidweapon'] = 'invalid weapon',
   ['commanderror_console'] = 'that command cannot be run from console',
-  ['commanderror_invalidcommand'] = '^3%s^0 is not a valid command!',
   ['commanderror_invalidplayerid'] = 'there is no player online matching that server id',
   ['commandgeneric_playerid'] = 'player id',
 

--- a/locales/fi.lua
+++ b/locales/fi.lua
@@ -97,7 +97,6 @@ Locales['fi'] = {
   ['commanderror_invaliditem'] = 'invalid item name',
   ['commanderror_invalidweapon'] = 'invalid weapon',
   ['commanderror_console'] = 'that command can not be run from console',
-  ['commanderror_invalidcommand'] = '^3%s^0 is not an valid command!',
   ['commanderror_invalidplayerid'] = 'there is no player online matching that server id',
   ['commandgeneric_playerid'] = 'player id',
 

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -97,7 +97,6 @@ Locales['fr'] = {
   ['commanderror_invaliditem'] = 'nom de l\'objet invalide',
   ['commanderror_invalidweapon'] = 'arme invalide',
   ['commanderror_console'] = 'cette commande ne peut pas être utilisée dans la console',
-  ['commanderror_invalidcommand'] = '^3%s^0 n\'est pas une commande valide!',
   ['commanderror_invalidplayerid'] = 'il n\'ya aucun joueur avec cet ID en jeu',
   ['commandgeneric_playerid'] = 'id joueur',
 

--- a/locales/pl.lua
+++ b/locales/pl.lua
@@ -96,7 +96,6 @@ Locales['pl'] = {
   ['commanderror_invaliditem'] = 'nieprawidłowa nazwa przedmiotu',
   ['commanderror_invalidweapon'] = 'nieprawidłowa broń',
   ['commanderror_console'] = 'podana komenda nie może zostać uruchomiona przez konsole',
-  ['commanderror_invalidcommand'] = '^3%s^0 nie jest poprawną komendą!',
   ['commanderror_invalidplayerid'] = 'brak dostepnego gracza pasującego do podanego id serwerowego',
   ['commandgeneric_playerid'] = 'id gracza',
 

--- a/locales/sc.lua
+++ b/locales/sc.lua
@@ -97,7 +97,6 @@ Locales['sc'] = {
   ['commanderror_invaliditem'] = '无效的物品名称',
   ['commanderror_invalidweapon'] = '无效武器',
   ['commanderror_console'] = '该命令不能从控制台运行',
-  ['commanderror_invalidcommand'] = '^3%s^0 不是有效的命令！',
   ['commanderror_invalidplayerid'] = '没有在线玩家匹配到该服务id',
   ['commandgeneric_playerid'] = '玩家id',
 

--- a/locales/sv.lua
+++ b/locales/sv.lua
@@ -97,7 +97,6 @@ Locales['sv'] = {
   ['commanderror_invaliditem'] = 'ej giltigt item',
   ['commanderror_invalidweapon'] = 'ej giltigt vapen',
   ['commanderror_console'] = 'detta kommando kan ej executas i konsol',
-  ['commanderror_invalidcommand'] = '^3%s^0 är inte ett giltigt kommando!',
   ['commanderror_invalidplayerid'] = 'det finns ingen spelare som matchar det angivna server id',
   ['commandgeneric_playerid'] = 'spelarid',
 

--- a/locales/tc.lua
+++ b/locales/tc.lua
@@ -97,7 +97,6 @@ Locales['tc'] = {
   ['commanderror_invaliditem'] = '無效的物品名稱',
   ['commanderror_invalidweapon'] = '無效武器',
   ['commanderror_console'] = '該指令不能從控制台執行',
-  ['commanderror_invalidcommand'] = '^3%s^0 不是有效的指令！',
   ['commanderror_invalidplayerid'] = '無效的玩家ID',
   ['commandgeneric_playerid'] = '玩家id',
 


### PR DESCRIPTION
Cleaning up translation files removed translation string commanderror_invalidcommand - since it's not used anymore after my earlyer pr.