### PR TITLE
Fixed wrong variable in states bag name

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -195,7 +195,7 @@ function loadESXPlayer(identifier, playerId, isNew)
 		-- Statebags
 		Player.firstName = userData.firstname
 		Player.lastName = userData.lastname
-		Player.name = ('%s %s'):format(userData.firstname, userData.playerName)
+		Player.name = ('%s %s'):format(userData.firstname, userData.lastname)
 		Player.job = jobObject.name
 		Player.grade = gradeObject.name
 		Player.admin = Core.IsPlayerAdmin(playerId)


### PR DESCRIPTION
Statebags was using the wrong var for the full name.

used playerName insted of lastName as the last part of the string.