### PR TITLE
fix(onesync): prevent ped spawn in vehicles

### DIFF
--- a/server/onesync.lua
+++ b/server/onesync.lua
@@ -55,10 +55,10 @@ ESX.OneSync.SpawnVehicle = function(model, coords, heading, cb)
 	CreateThread(function()
 		local entity = Citizen.InvokeNative(`CREATE_AUTOMOBILE`, model, coords.x, coords.y, coords.z, heading)
 		while not DoesEntityExist(entity) do Wait(50) end
+		cb(entity)
 
-		CreateThread(function()
-			local ped = GetPedInVehicleSeat(entity, -1)
-			if ped == 0 then return end
+		local ped = GetPedInVehicleSeat(entity, -1)
+		if ped > 0 then
 			for i=-1, 6 do
 				ped = GetPedInVehicleSeat(entity, i)
 				local popType = GetEntityPopulationType(ped)
@@ -66,8 +66,7 @@ ESX.OneSync.SpawnVehicle = function(model, coords, heading, cb)
 					DeleteEntity(ped)
 				end
 			end
-		end)
-		cb(entity)
+		end
 	end)
 end
 

--- a/server/onesync.lua
+++ b/server/onesync.lua
@@ -3,7 +3,7 @@ ESX.OneSync = {}
 ---@param source vector|number either coordinates to originate from, or a player id
 ---@param closest boolean
 ---@param distance number
----@param ignore boolean 
+---@param ignore boolean
 ---@return table
 function ESX.OneSync.Players(source, closest, distance, ignore)
 	local result = {}
@@ -55,6 +55,18 @@ ESX.OneSync.SpawnVehicle = function(model, coords, heading, cb)
 	CreateThread(function()
 		local entity = Citizen.InvokeNative(`CREATE_AUTOMOBILE`, model, coords.x, coords.y, coords.z, heading)
 		while not DoesEntityExist(entity) do Wait(50) end
+
+		CreateThread(function()
+			local ped = GetPedInVehicleSeat(entity, -1)
+			if ped == 0 then return end
+			for i=-1, 6 do
+				ped = GetPedInVehicleSeat(entity, i)
+				local popType = GetEntityPopulationType(ped)
+				if popType <= 5 or popType >= 1 then
+					DeleteEntity(ped)
+				end
+			end
+		end)
 		cb(entity)
 	end)
 end


### PR DESCRIPTION
Sometimes, CreateAutomobile is creating ped inside created vehicles. It only happens when spawning a model which is also spawned by clients in the same area as POPTYPE_RANDOM_PERMANENT (even if this native only create POPTYPE_PERMANENT entities).